### PR TITLE
select mode is inactivated when template deleted

### DIFF
--- a/src/components/dashboardComponents/ChooseDateForm.js
+++ b/src/components/dashboardComponents/ChooseDateForm.js
@@ -42,6 +42,8 @@ const ChooseDateForm = ({
     await deleteTemplate(id);
     const templates = templateList.filter(template => template._id !== id);
     setTemplateList(templates);
+    clearSelected();
+    setTemplateFormOpen(false);
   };
 
   const applyTemplate = (summary, description, starttime, endtime) => {

--- a/src/components/dashboardComponents/calendarComponents/Calendar.js
+++ b/src/components/dashboardComponents/calendarComponents/Calendar.js
@@ -107,7 +107,7 @@ const MonthNameContainer = styled.div`
   box-sizing: border-box;
 
   @media(max-width: 1700px){
-    width: 20%;
+    width: 30%;
   }
   @media(max-width: 1400px){
     width: 25%;


### PR DESCRIPTION
# Description
When a template is deleted, dates are deselected and date selection mode is terminated
Fixes # (issue)
Previously, when user would delete a template they would continue to be able to select dates with no way to exit that mode.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

