### PR TITLE
removed text selection from events

### DIFF
--- a/src/components/mobile/eventComponents/MobileChooseDateForm.js
+++ b/src/components/mobile/eventComponents/MobileChooseDateForm.js
@@ -114,6 +114,11 @@ const EventDiv = styled.div`
     width: 90%;
     font-size: 20px;
     line-height: 27px;
+    -moz-user-select: none;
+   -khtml-user-select: none;
+   -webkit-user-select: none;
+   -ms-user-select: none;
+   user-select: none;
 `;
 
 const Title = styled.p`


### PR DESCRIPTION
# Description
removes ability to select text on events

Fixes # (issue)
prevents unintended text selection when long tapping to delete an event template


