### PR TITLE
UI fixes

### DIFF
--- a/src/components/contacts/Contacts.js
+++ b/src/components/contacts/Contacts.js
@@ -14,9 +14,9 @@ const Contacts = () => {
 
     const [viewContacts, setViewContacts] = useState([]);
 
-    const handleAddContact = () => {
-        console.log('click: ', navState)
-       setNavState(9)
+    const handleAddContact = (e) => {
+        e.stopPropagation();
+        setNavState(9)
     }
 
 
@@ -78,7 +78,7 @@ const Contacts = () => {
                 <Button>Add to group</Button>
             </BtnDiv>
             <BtnDiv>
-                <BtnContact1 onClick={handleAddContact} style={{ background: 'white', border: '2px solid #28807D', color: '#28807D' }}>Add Contact</BtnContact1>
+                <BtnContact1 onClick={(e) => handleAddContact(e)} style={{ background: 'white', border: '2px solid #28807D', color: '#28807D' }}>Add Contact</BtnContact1>
                 <BtnContact2>Invite Contact</BtnContact2>
             </BtnDiv>
             </ContactDiv>

--- a/src/components/groups/Groups_Contacts.js
+++ b/src/components/groups/Groups_Contacts.js
@@ -8,16 +8,13 @@ const Groups_Contacts = () => {
 
     const { setNavState } = useContext(Context);
 
+    // control display: true = contacts, false = groups
     const [navToggle, setNavToggle] = useState(false);
 
 
     const handleBack = () => {
         setNavState(0);
     }
-    const handleChange = () => {
-        console.log('changing navToggle from ', navToggle);
-        setNavToggle(!navToggle)
-    };
 
     return(
         <Container>
@@ -28,8 +25,8 @@ const Groups_Contacts = () => {
                 <BackBtn onClick={handleBack}>Back</BackBtn>
             </NavContainer>
             <TabsContainer style={{ justifyContent: 'flex-end'}}>
-                <Tabs className='buttons' onClick={handleChange}>Groups</Tabs>
-                <Tabs className='buttons' onClick={handleChange}>Contacts</Tabs>
+                <Tabs className='buttons' onClick={() => setNavToggle(false)}>Groups</Tabs>
+                <Tabs className='buttons' onClick={() => setNavToggle(true)}>Contacts</Tabs>
             </TabsContainer>
             <div>
                 {navToggle ? <Contacts /> : <Groups />}

--- a/src/components/groups/Groups_Contacts.js
+++ b/src/components/groups/Groups_Contacts.js
@@ -81,5 +81,6 @@ const BackBtn = styled.p`
   text-align: right;
   line-height: 27px;
   color: #28807d;
+  cursor: pointer;
 `;
 

--- a/src/components/groups/Groups_Contacts.js
+++ b/src/components/groups/Groups_Contacts.js
@@ -28,9 +28,9 @@ const Groups_Contacts = () => {
                 <Tabs className='buttons' onClick={() => setNavToggle(false)}>Groups</Tabs>
                 <Tabs className='buttons' onClick={() => setNavToggle(true)}>Contacts</Tabs>
             </TabsContainer>
-            <div>
+            <ContentContainer>
                 {navToggle ? <Contacts /> : <Groups />}
-            </div>
+            </ContentContainer>
         </Container>
     )
 }
@@ -81,3 +81,6 @@ const BackBtn = styled.p`
   cursor: pointer;
 `;
 
+const ContentContainer = styled.div`
+    width: 90%;
+`;


### PR DESCRIPTION
# Description

Fixes the following UI bugs:

-'back' button in groups not appearing clickable to the user
-the toggle in groups_contacts toggling between the tabs even if the user is clicking on the same tab
-the content of contacts and groups appearing skewed to one side inside the container
-admin add contact form not displaying on 'add contact'

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)